### PR TITLE
pip 19 needs a cache directory, we still purge it at the end

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ RUN \
  pip install --no-cache-dir -U \
 	pip \
 	setuptools && \
- pip install --no-cache-dir -U \
+ pip install -U \
 	configparser \
 	ndg-httpsclient \
 	notify \


### PR DESCRIPTION
We need to see what is broken downstream also, only specific packages need the cache directory.